### PR TITLE
Multi-arch images (amd64 + arm64) + Docker Hub overview

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -31,13 +31,13 @@ jobs:
         variant: ["apache", "fpm"]
         php: ["8.1", "8.2", "8.3"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU (for arm64 cross-build)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Decide whether to push
         id: cfg
@@ -50,13 +50,13 @@ jobs:
 
       - name: Login to Docker Hub
         if: steps.cfg.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push dev-${{ matrix.variant }}-${{ matrix.php }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./dev/php-${{ matrix.variant }}-${{ matrix.php }}
           file: ./dev/php-${{ matrix.variant }}-${{ matrix.php }}/Dockerfile

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU (for arm64 cross-build)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -57,6 +60,7 @@ jobs:
         with:
           context: ./dev/php-${{ matrix.variant }}-${{ matrix.php }}
           file: ./dev/php-${{ matrix.variant }}-${{ matrix.php }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ steps.cfg.outputs.push }}
           tags: ${{ env.IMAGE }}:dev-${{ matrix.variant }}-${{ matrix.php }}
           cache-from: type=gha

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -15,11 +15,11 @@ jobs:
   description:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Update Docker Hub description
         if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -14,11 +14,14 @@ on:
 jobs:
   description:
     runs-on: ubuntu-latest
+    # secrets can't be used directly in `if`; surface it via env first.
+    env:
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Update Docker Hub description
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: env.HAS_DOCKERHUB == 'true'
         uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,28 @@
+name: Sync Docker Hub description
+
+# Pushes DOCKERHUB.md to the Docker Hub repository's overview/description and sets
+# the short description. Runs on master when DOCKERHUB.md changes, or on demand.
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'DOCKERHUB.md'
+      - '.github/workflows/dockerhub-description.yml'
+  workflow_dispatch:
+
+jobs:
+  description:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Docker Hub description
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: melisplatform/melis-docker
+          short-description: "Ready-to-run Docker images for Melis Platform (PHP/Laminas CMS) — multi-arch, web installer."
+          readme-filepath: ./DOCKERHUB.md

--- a/.github/workflows/prebuilt-image.yml
+++ b/.github/workflows/prebuilt-image.yml
@@ -42,13 +42,13 @@ jobs:
             pinned: fpm-php8.3
             tagsuffix: "-fpm"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up QEMU (for arm64 cross-build)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       # Only push on master / tags, and only when Docker Hub creds are configured.
       - name: Decide whether to push
@@ -62,14 +62,14 @@ jobs:
 
       - name: Login to Docker Hub
         if: steps.cfg.outputs.push == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker metadata (tags / labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -78,7 +78,7 @@ jobs:
             type=ref,event=tag,suffix=${{ matrix.tagsuffix }}
 
       - name: Build and push (${{ matrix.dir }}/)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./${{ matrix.dir }}
           file: ./${{ matrix.dir }}/Dockerfile

--- a/.github/workflows/prebuilt-image.yml
+++ b/.github/workflows/prebuilt-image.yml
@@ -44,6 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up QEMU (for arm64 cross-build)
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -79,6 +82,7 @@ jobs:
         with:
           context: ./${{ matrix.dir }}
           file: ./${{ matrix.dir }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: ${{ steps.cfg.outputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,0 +1,57 @@
+# Melis Platform — Docker images
+
+Ready-to-run Docker images for [**Melis Platform**](https://www.melistechnology.com/),
+the PHP / Laminas CMS. Pull an image, point it at a MySQL database, and finish the
+setup through the native Melis **web installer** (DB schema, admin user, optional demo).
+
+Images are **multi-arch** (`linux/amd64` + `linux/arm64`, so they run natively on
+Intel/AMD and on Apple Silicon).
+
+Source & full docs: **https://github.com/melisplatform/melis-docker**
+
+## Tags
+
+| Tag | What it is |
+|-----|-----------|
+| `latest`, `php8.3` | **Pre-built** Melis (Apache + mod_php), skeleton baked in — just add a DB |
+| `fpm-latest`, `fpm-php8.3` | **Pre-built** Melis for an **nginx + PHP-FPM** stack, skeleton baked in |
+| `dev-apache-8.1` … `8.3` | Dev **base** images (PHP + Apache + Composer) to mount your own project |
+| `dev-fpm-8.1` … `8.3` | Dev **base** images (PHP-FPM + Composer) to put behind your own nginx |
+| `dev-apache-7.x` | **Legacy** (PHP 7, **not** compatible with current Melis 5.3.x — kept for old projects) |
+
+> Melis 5.3.x requires **PHP 8.1 – 8.3** (`composer ^8.1|^8.3`). Prefer a PHP 8 tag.
+
+## Quick start
+
+The fastest path — pull and run, then bring any MySQL 8.x:
+
+```bash
+docker run -d --name melis -p 8080:80 \
+  -e MYSQL_HOST=your-db-host \
+  -e MYSQL_DATABASE=melis \
+  -e MYSQL_USER=melis \
+  -e MYSQL_PASSWORD=melis \
+  melisplatform/melis-docker:latest
+```
+
+> `MYSQL_HOST` must be a hostname **without** `:port` (e.g. `db`, not `db:3306`).
+
+Then open **http://localhost:8080** and follow the web installer.
+
+Prefer a one-command stack that includes the database? Use a compose file from the
+repository:
+
+- [`prebuilt/`](https://github.com/melisplatform/melis-docker/tree/master/prebuilt) — Apache image + MySQL
+- [`fpm/`](https://github.com/melisplatform/melis-docker/tree/master/fpm) — nginx + PHP-FPM + MySQL
+- [`install/`](https://github.com/melisplatform/melis-docker/tree/master/install) — turnkey build with editable code on the host
+
+## Notes
+
+- The baked images ship the Melis **Community Edition** skeleton; the installer adds
+  CMS / Front / Engine / demo as you choose.
+- Designed for **local evaluation / development**. For production, see the project's
+  Kubernetes / OCI deployment.
+
+## License
+
+OSL-3.0 — see the [repository](https://github.com/melisplatform/melis-docker).


### PR DESCRIPTION
## Why

The images published from #6 were **amd64-only**, so `docker pull` fails on arm64
hosts (Apple Silicon):

```
no matching manifest for linux/arm64/v8 in the manifest list entries
```

## Changes

- **Multi-arch builds**: add `docker/setup-qemu-action` and
  `platforms: linux/amd64,linux/arm64` to both image workflows, so every tag
  (`latest`, `php8.3`, `fpm-*`, `dev-apache-8.x`, `dev-fpm-8.x`) runs natively on
  Intel/AMD **and** ARM.
- **Docker Hub overview**: add `DOCKERHUB.md` (tags, quick start, DB/installer notes)
  and a workflow that syncs it to the Docker Hub repository description via the
  existing `DOCKERHUB_*` secrets.

## Note

The baked images now also cross-build for arm64 under emulation, so the
master deploy will take noticeably longer than the amd64-only run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)