### PR TITLE
Add PHP 8.4 dev base images (latest stays 8.3)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,7 @@
 name: Dev base images
 
 # Builds the per-PHP-version Melis dev base images under dev/ — both the Apache
-# (mod_php) and PHP-FPM variants, PHP 8.1–8.3 (the versions Melis 5.3.x supports:
+# (mod_php) and PHP-FPM variants, PHP 8.1–8.4 (8.4 via the maintained Laminas forks; see melis-core#24) (composer
 # composer constraint ^8.1|^8.3). Pushes to Docker Hub as
 # melisplatform/melis-docker:dev-{apache,fpm}-<version> on master only; pull
 # requests build without pushing (no secrets required).
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         variant: ["apache", "fpm"]
-        php: ["8.1", "8.2", "8.3"]
+        php: ["8.1", "8.2", "8.3", "8.4"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ docker-compose down -v
 Change PHP version in **app/latest/.env** (default **dev-apache-8.3**)
 
 Available tags (PHP versions shipped in [`dev/`](dev/)) — [View on Docker Hub](https://hub.docker.com/repository/docker/melisplatform/melis-docker):
-* dev-apache-8.3  ← recommended (latest version supported by Melis 5.3.x)
-* dev-apache-8.2
-* dev-apache-8.1
 
-> Melis Platform 5.3.x requires **PHP 8.1 – 8.3** (composer `^8.1|^8.3`). The old
-> `dev-apache-7.x` tags are **not compatible** with current Melis and are no longer
-> shipped here; older images may still exist on Docker Hub for legacy projects.
+Apache (`mod_php`) — `dev-apache-8.1`, `dev-apache-8.2`, **`dev-apache-8.3`** (recommended), `dev-apache-8.4`
+PHP-FPM — `dev-fpm-8.1`, `dev-fpm-8.2`, `dev-fpm-8.3`, `dev-fpm-8.4`
+
+> **PHP 8.3** is the recommended/default version (officially supported by Melis 5.3.x).
+> **PHP 8.4** works via the maintained Laminas forks (see melisplatform/melis-core#24);
+> it ships as an additional tag — `latest` stays on 8.3 until 8.4 is fully released
+> upstream. The old `dev-apache-7.x` tags are **not compatible** with current Melis.
 
 
 ## Contributing

--- a/dev/php-apache-8.4/Dockerfile
+++ b/dev/php-apache-8.4/Dockerfile
@@ -1,0 +1,29 @@
+# Melis Platform — dev base image (PHP 8.4 + Apache + Composer)
+# A ready-to-use PHP/Apache base with the extensions Melis needs. Mount your Melis
+# project into the container (see app/latest/ for a full local dev stack).
+# Build: docker build -t melisplatform/melis-docker:dev-apache-8.4 .
+FROM php:8.4-apache
+
+ARG TZ=Europe/Paris
+ENV TZ=${TZ}
+
+# System packages + PHP extensions required by Melis (intl needs libicu-dev)
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git unzip curl wget vim \
+        default-mysql-client \
+        libxml2-dev libonig-dev libcurl4-gnutls-dev libzip-dev \
+        libjpeg-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libpng-dev \
+        libicu-dev tzdata \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif opcache \
+    && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
+    && rm -rf /var/lib/apt/lists/*
+
+# Composer (official image) + Apache modules Melis relies on
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+RUN a2enmod rewrite headers
+
+EXPOSE 80
+CMD ["apache2-foreground"]

--- a/dev/php-fpm-8.4/Dockerfile
+++ b/dev/php-fpm-8.4/Dockerfile
@@ -1,0 +1,28 @@
+# Melis Platform — dev base image (PHP 8.4 FPM + Composer)
+# PHP-FPM base with the extensions Melis needs (listens on :9000). Put a web server
+# (e.g. nginx) in front — see fpm/ for a ready-to-run nginx + php-fpm stack.
+# Build: docker build -t melisplatform/melis-docker:dev-fpm-8.4 .
+FROM php:8.4-fpm
+
+ARG TZ=Europe/Paris
+ENV TZ=${TZ}
+
+# System packages + PHP extensions required by Melis (intl needs libicu-dev)
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git unzip curl wget vim \
+        default-mysql-client \
+        libxml2-dev libonig-dev libcurl4-gnutls-dev libzip-dev \
+        libjpeg-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libpng-dev \
+        libicu-dev tzdata \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j"$(nproc)" \
+        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif opcache \
+    && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
+    && rm -rf /var/lib/apt/lists/*
+
+# Composer (official image)
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+EXPOSE 9000
+CMD ["php-fpm"]


### PR DESCRIPTION
## What

Adds **PHP 8.4** dev base images and builds them in CI:
- `dev/php-apache-8.4/` → `melisplatform/melis-docker:dev-apache-8.4`
- `dev/php-fpm-8.4/` → `melisplatform/melis-docker:dev-fpm-8.4`
- `docker-image.yml` matrix now `{apache,fpm} × {8.1,8.2,8.3,8.4}`

## Why now

Melis 5.3.x resolves & installs on **PHP 8.4** since **melis-core v5.3.36**
(servicemanager `^3.22.1` + serializer `^2.17 || ^3.0`) plus the maintained Laminas
forks wired via the skeleton `repositories` — verified end-to-end on PHP 8.4.22.

## `latest` stays on 8.3 (deliberate)

8.4 ships as an **additional** tag. `latest` remains PHP **8.3** (Melis' officially
supported default) until:
1. the skeleton `composer.lock` is regenerated on 8.4 (so `create-project` works
   out-of-the-box — see melisplatform/melis-core#24),
2. the module deprecation-fix PRs are released,
3. 8.4 has some real-world mileage.

Baked **prebuilt/fpm** 8.4 images will follow once the skeleton lock is regenerated
(then no build-time workaround is needed).

## Verified
`docker build ./dev/php-apache-8.4` → PHP 8.4.22, extensions (pdo_mysql/intl/gd/zip/mysqli) + Composer OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)