### PR TITLE
PHP 8.5 dev images + configurable PHP, local proxy, DX tooling & docs

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,9 @@
 name: Dev base images
 
 # Builds the per-PHP-version Melis dev base images under dev/ — both the Apache
-# (mod_php) and PHP-FPM variants, PHP 8.1–8.4 (8.4 via the maintained Laminas forks; see melis-core#24) (composer
-# composer constraint ^8.1|^8.3). Pushes to Docker Hub as
+# (mod_php) and PHP-FPM variants, PHP 8.1–8.5 (composer constraint ^8.1|^8.3).
+# 8.4 and 8.5 build on the maintained Laminas forks (see melis-core#24) and are
+# experimental — not yet officially listed by Melis. Pushes to Docker Hub as
 # melisplatform/melis-docker:dev-{apache,fpm}-<version> on master only; pull
 # requests build without pushing (no secrets required).
 
@@ -29,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         variant: ["apache", "fpm"]
-        php: ["8.1", "8.2", "8.3", "8.4"]
+        php: ["8.1", "8.2", "8.3", "8.4", "8.5"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,10 @@
 name: Dev base images
 
 # Builds the per-PHP-version Melis dev base images under dev/ — both the Apache
-# (mod_php) and PHP-FPM variants, PHP 8.1–8.5 (composer constraint ^8.1|^8.3).
-# 8.4 and 8.5 build on the maintained Laminas forks (see melis-core#24) and are
-# experimental — not yet officially listed by Melis. Pushes to Docker Hub as
+# (mod_php) and PHP-FPM variants, PHP 8.1–8.5. These are pure PHP base images.
+# 8.4 runs Melis (experimental). 8.5 base images build, but Melis does NOT run on
+# 8.5 yet — the skeleton's Laminas deps cap at 8.4 (see melis-core#24); the 8.5
+# tags are forward-looking. Pushes to Docker Hub as
 # melisplatform/melis-docker:dev-{apache,fpm}-<version> on master only; pull
 # requests build without pushing (no secrets required).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,13 @@ authoritative; scripting it is fragile and was a deliberate non-goal.
 
 - **Stack baseline:** PHP **8.3** (mod_php for apache variants, php-fpm for fpm),
   Apache 2.4 / nginx 1.27, **MySQL 8.4 LTS**.
+- **PHP version is configurable** in the runnable stacks (`install/`, `prebuilt/`,
+  `fpm/`): `ARG PHP_VERSION=8.3` → `FROM php:${PHP_VERSION}-{apache,fpm}`, wired into
+  compose build args and `.env` (`PHP_VERSION=`). 8.4 is experimental but runs;
+  8.5 builds the image but Melis won't install (Laminas deps cap at 8.4) — use 8.3/8.4.
+- **Root `Makefile`** wraps the common compose ops: `make up|up-build|down|destroy|
+  logs|shell|ps STACK=install|prebuilt|fpm|app/latest`, plus `proxy-up`, `PROXY=1`,
+  and `adminer` (DB GUI on :8082). `make help` lists all.
 - **Required PHP extensions:** `pdo_mysql` + `intl` are mandatory, plus
   `mysqli, gd, zip, mbstring, xml, curl, exif, opcache`. `gd` is configured
   `--with-freetype --with-jpeg`; `intl` needs `libicu-dev`.
@@ -64,11 +71,17 @@ authoritative; scripting it is fragile and was a deliberate non-goal.
 5. **`prebuilt/`: never bind-mount a host dir over `/var/www/melis`** — it would
    mask the baked code. Use the **named volume** `melis-app` (seeded from the image
    on first run). `fpm/clear_env=no` so PHP-FPM sees `getenv(MYSQL_*)`.
-6. **PHP 7.x is incompatible** with current Melis (`require php: ^8.1|^8.3`). PHP
-   **8.4 and 8.5** work via maintained Laminas forks (see `melisplatform/melis-core#24`)
-   and ship as extra `dev-*-8.4` / `dev-*-8.5` tags (experimental), but `latest`
-   stays on **8.3** (the max version Melis officially lists) until they are listed
-   upstream.
+6. **PHP 7.x is incompatible** with current Melis (`require php: ^8.1|^8.3`). **PHP 8.4**
+   runs Melis (every dependency allows `~8.4`) and is the experimental ceiling. **PHP 8.5
+   does NOT run Melis yet** (verified 2026-06-13): the skeleton's Laminas deps
+   (laminas-mvc, -servicemanager, -mime, -math, melis-core…) cap at 8.4, so
+   `composer install` fails on 8.5 — at run time for `install/`, at *build* time for
+   `prebuilt/`/`fpm/` (they bake the skeleton). `dev-*-8.5` images build (pure PHP base,
+   forward-looking). `latest` stays on 8.3. See `melisplatform/melis-core#24`.
+7. **PHP 8.5 build gotcha: don't `docker-php-ext-install opcache`** — on 8.5 Zend
+   OPcache is built into core (no shared module), so it fails with
+   `cp: cannot stat 'modules/*'`. All Dockerfiles gate it on `version_compare(...,
+   "8.5", "<")` so opcache is installed only on < 8.5 (it's already loaded on 8.5).
 
 ## Shared local proxy (opt-in, `local-proxy/` + `*/docker-compose.proxy.yml`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## What this repo is
+
+`melis-docker` — the public Docker tooling for **Melis Platform** (a PHP/Laminas
+CMS, modules `melisplatform/*`, version line 5.3.x). It ships Dockerfiles,
+docker-compose stacks and CI to install/run Melis with one command. It does **not**
+contain Melis itself — the application code comes from the Packagist skeleton
+`melisplatform/melis-platform-skeleton` (Melis CE), pulled via Composer.
+
+There is no application source, no test suite, no build step to run here — the
+"code" is Dockerfiles, compose files, shell entrypoints and GitHub Actions. Verify
+changes by building/running the relevant stack, not by unit tests.
+
+## The five paths (each is self-contained in its own folder)
+
+| Folder | What it does | Audience |
+|---|---|---|
+| [`prebuilt/`](prebuilt/) | Pulls a **pre-built** image that bakes the skeleton at build time + a MySQL service. No build on the user's machine. | Fastest "just run it" |
+| [`install/`](install/) | **Turnkey build**: builds locally, `composer create-project` the skeleton at first run into `./melis` (editable on host) + MySQL. | Devs who want code locally |
+| [`fpm/`](fpm/) | Production-style **nginx + PHP-FPM + MySQL**, skeleton baked into the image. | More production-like topology |
+| [`app/latest/`](app/latest/) | **Legacy** dev path: mounts an existing Melis project (`../../../`) into a PHP-8.3-apache build. | Existing projects |
+| [`dev/`](dev/) | Per-PHP-version **base images** only (no compose). `dev-{apache,fpm}-{8.1,8.2,8.3,8.4}`. | Image building blocks |
+| [`local-proxy/`](local-proxy/) | Shared **nginx-proxy** (opt-in) so several stacks share `:80` by hostname. | Running many projects locally |
+
+All paths finish the same way: the **native Melis web installer** at
+http://localhost:8080 (`/melis/setup`) sets up the DB schema, admin user and the
+optional demo site. **We never script the Melis install** — the web wizard is
+authoritative; scripting it is fragile and was a deliberate non-goal.
+
+## Architecture conventions
+
+- **Stack baseline:** PHP **8.3** (mod_php for apache variants, php-fpm for fpm),
+  Apache 2.4 / nginx 1.27, **MySQL 8.4 LTS**.
+- **Required PHP extensions:** `pdo_mysql` + `intl` are mandatory, plus
+  `mysqli, gd, zip, mbstring, xml, curl, exif, opcache`. `gd` is configured
+  `--with-freetype --with-jpeg`; `intl` needs `libicu-dev`.
+- **Composer is required in the image** — not just for bootstrap but because the
+  Melis web installer adds modules (cms/front/engine) via Composer at install time.
+- Each folder keeps its own `Dockerfile`, `docker-compose.yml`, `entrypoint.sh`,
+  `.env.example`, `conf/`, `README.md`. Keep them consistent across folders when
+  changing shared logic (extensions, MySQL wait loop, collation, perms).
+
+## Hard-won gotchas — respect these (they cost real debugging)
+
+1. **`MYSQL_HOST` / `MYSQL_HOSTNAME` must NOT contain `:port`.** Use `melis-db`,
+   never `melis-db:3306`. A `host:port` value makes Melis' flyway/JDBC build a
+   double-port URL and breaks. (Was the legacy `app/latest` bug.)
+2. **Do DB readiness checks via PHP/mysqli, not the `mysql` CLI.** The MariaDB
+   client (`default-mysql-client`) rejects MySQL 8.x's self-signed TLS cert.
+   Entrypoints wait on MySQL with PHP. When passing creds to `php -r`, pass them as
+   **environment** (prefix `DB_HOST=… php -r …`), not as `$argv` — the original
+   entrypoints passed them as args, `getenv()` returned empty, the loop spun
+   forever and **Apache never started (HTTP 000)**. Also set
+   `mysqli_report(MYSQLI_REPORT_OFF)` (PHP 8.1+ throws instead of returning false)
+   and bound the retry (~3 min) so Apache always comes up.
+3. **DB collation must be `utf8mb4_general_ci`.** The Melis installer rejects
+   `utf8mb4_unicode_ci` at "Test database connection". Set it in both the compose
+   `--collation-server` and the entrypoint `CREATE DATABASE`.
+4. **MySQL 8.4 removed `--default-authentication-plugin`** — don't pass it; rely on
+   the server default (`caching_sha2_password`), which PHP 8.x connects to natively.
+5. **`prebuilt/`: never bind-mount a host dir over `/var/www/melis`** — it would
+   mask the baked code. Use the **named volume** `melis-app` (seeded from the image
+   on first run). `fpm/clear_env=no` so PHP-FPM sees `getenv(MYSQL_*)`.
+6. **PHP 7.x is incompatible** with current Melis (`require php: ^8.1|^8.3`). PHP
+   **8.4** works via maintained Laminas forks (see `melisplatform/melis-core#24`)
+   and ships as an extra `dev-*-8.4` tag, but `latest` stays on **8.3** (the max
+   version Melis officially lists) until 8.4 is fully released upstream.
+
+## Shared local proxy (opt-in, `local-proxy/` + `*/docker-compose.proxy.yml`)
+
+`nginxproxy/nginx-proxy` on a shared external `webproxy` network owns `:80` and
+routes by container `VIRTUAL_HOST`. Each runnable stack has a
+`docker-compose.proxy.yml` override that: declares `VIRTUAL_HOST`/`VIRTUAL_PORT`,
+joins `webproxy`, and **drops the published host port via the Compose `!reset []`
+tag**. Activated by adding `-f docker-compose.proxy.yml`; without it, stacks behave
+exactly as before (published on `HOST_PORT`). The proxy targets the `php` service
+(install/prebuilt/app-latest) or the nginx `web` service (fpm — php is FPM-only).
+Default hosts: `melis-{prebuilt,install,fpm,app}.local`. To run several at once,
+set distinct `MELIS_CONTAINER_NAME` + `VIRTUAL_HOST` per `.env`. Mirrors the setup
+in the sibling `../melis-platform-website` project. Validate edits with
+`docker compose -f docker-compose.yml -f docker-compose.proxy.yml config`.
+
+## Security / hygiene
+
+- **Never commit a real `.env` or any secret** — `.env.example` only. `.gitignore`
+  ignores `**/.env`, `install/melis/`, `.claude/settings.local.json`, `.DS_Store`.
+- DB ports are bound to `127.0.0.1` (not exposed on the LAN).
+- Web services have a `HEALTHCHECK`; Apache gets an explicit `ServerName localhost`
+  to silence `AH00558`.
+
+## CI (GitHub Actions, all multi-arch `linux/amd64,linux/arm64`)
+
+- **`docker-image.yml`** — builds `dev/` base images, matrix `{apache,fpm} × {8.1..8.4}`,
+  pushes `melisplatform/melis-docker:dev-{variant}-{php}` on `master` only.
+- **`prebuilt-image.yml`** — builds the baked images: `prebuilt/` → `latest`/`php8.3`,
+  `fpm/` → `fpm-latest`/`fpm-php8.3`; pushes on `master` pushes and `v*` tags.
+- **`dockerhub-description.yml`** — syncs `DOCKERHUB.md` to the Docker Hub overview.
+- PRs **build-only** (no push, no secrets needed). Pushing requires repo secrets
+  `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN`. Pushing a `.github/workflows/*` change
+  needs the `workflow` scope on the `gh` token.
+
+## How to test a change locally
+
+```bash
+# Pre-built (validated E2E): build the baked image, then run image + db
+cd prebuilt && docker build -t melisplatform/melis-docker:latest . \
+  && cp -n .env.example .env && docker compose up -d
+# Turnkey: builds + composer create-project on first run (slow first time)
+cd install && cp -n .env.example .env && docker compose up --build
+# nginx + php-fpm
+cd fpm && cp -n .env.example .env && docker compose up --build   # default 8080
+```
+Then open http://localhost:8080 — expect `/` → 302 → `/melis/setup` → 200, and
+drive the wizard (DB host = `melis-db` **without port**, db/user/pass = `melis`).
+Baked images are ~1.5 GB each; `docker rmi` test images when done.
+
+## Notes
+
+- [`HANDOFF.md`](HANDOFF.md) is the detailed session log / decision record — read it
+  for the full backstory, upstream PRs (melis-installer #19/#20/#21) and roadmap.
+- The repo lives next to a private `../demo` (the Melis demo on OCI/Kubernetes);
+  the gotchas above are shared lessons from that deployment.
+- Cloud sync (iCloud/Dropbox) occasionally drops `* 2.ext` / `* 3.ext` duplicate
+  files in the tree. They are not part of the build — delete them. Find with:
+  `find . -not -path './.git/*' \( -name '* [0-9].*' -o -name '* [0-9]' \)`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,23 +75,39 @@ authoritative; scripting it is fragile and was a deliberate non-goal.
    on first run). `fpm/clear_env=no` so PHP-FPM sees `getenv(MYSQL_*)`.
 6. **PHP 7.x is incompatible** with current Melis (`require php: ^8.1|^8.3`). **PHP 8.4**
    runs Melis (every dependency allows `~8.4`) and is the experimental ceiling. **PHP 8.5
-   is not usable out of the box yet** — but it's NOT a hard incompatibility (diagnosed
-   end-to-end 2026-06-13). Two distinct blockers:
-   - **Composer constraints:** the skeleton's Laminas deps (laminas-mvc, -servicemanager,
-     -mime, -math, melis-core…) cap at `~8.4`, so a normal `composer install` refuses 8.5
-     — at run time for `install/`, at *build* time for `prebuilt/`/`fpm/` (they bake the
-     skeleton). Bypassable with `composer --ignore-platform-reqs`.
-   - **8.5 deprecation breaks the web installer:** with platform reqs forced, Melis runs,
-     but the installer's DB step fails. Root cause: `melis-installer`
-     `InstallHelperService.php` uses the **deprecated `PDO::MYSQL_ATTR_INIT_COMMAND`**
-     (E_DEPRECATED on 8.5), and `melis-core` (`Module.php` + `config/app.interface.php`)
-     forces `display_errors=1` and `error_reporting = E_ALL & ~E_USER_DEPRECATED` (does
-     NOT exclude core `E_DEPRECATED`). So the deprecation text is printed into the AJAX
-     reply, breaking the JSON the wizard parses — even though the DB check itself returns
-     `success:1`. **Upstream fixes:** (a) use `Pdo\Mysql::ATTR_INIT_COMMAND`; (b) exclude
-     `E_DEPRECATED` / set `display_errors=0`. Patching the constant in-container → clean
-     JSON, verified.
-   `dev-*-8.5` images build (pure PHP base, forward-looking). `latest` stays on 8.3.
+   is NOT a hard incompatibility** — Melis was driven through a full install to the
+   working back-office on 8.5 (verified end-to-end 2026-06-13), but only after several
+   fixes; out of the box it does not complete. `latest` stays on 8.3; `dev-*-8.5` images
+   build (pure PHP base, forward-looking). The complete 8.5 recipe:
+   - **(infra, shipped) git over HTTPS:** on 8.5 Composer must resolve the public
+     melisplatform Laminas forks from their **VCS source** (locked dist versions don't
+     satisfy 8.5), which are declared as `git@github.com:` (SSH) URLs — the image has no
+     ssh client/keys, so module download fails ("cannot run ssh"). Fix shipped in
+     `install/prebuilt/fpm` Dockerfiles: `git config --system url.https://github.com/.insteadOf git@github.com:`.
+     This was THE hard blocker; once fixed, all modules (cms/front/engine + demo) install.
+   - **(infra, shipped) don't display errors:** php.ini sets `display_errors=Off` +
+     `error_reporting` excluding `E_DEPRECATED` — 8.5 emits many deprecations from
+     Melis/Laminas/phing; if displayed they pollute installer AJAX (the DB-test JSON) and
+     clutter the back-office. (Melis also re-sets these at runtime from its config, incl.
+     the generated `module/MelisModuleConfig/config/app.interface.php` `local` block.)
+   - **(upstream Melis) error display is forced on:** Melis re-applies error config at
+     runtime (`melis-core` `Module.php` `ini_set`), and the value that wins the
+     `meliscore.datas.default.errors` config merge is **`melis-installer`'s**
+     `config/app.interface.php` (`display_errors=1`, `error_reporting=E_ALL & ~E_USER_DEPRECATED`
+     — does not exclude core `E_DEPRECATED`). So it overrides our php.ini `display_errors=Off`
+     for back-office pages → 8.5 deprecations are displayed. Upstream fix: set
+     `display_errors=0` / exclude `E_DEPRECATED` in melis-installer (and melis-core) config.
+   - **(upstream Melis, NOT done here) code is not 8.5-deprecation-clean:**
+     `melis-installer` uses deprecated `PDO::MYSQL_ATTR_INIT_COMMAND` (→ `Pdo\Mysql::ATTR_INIT_COMMAND`);
+     `melis-core` `MelisCoreToolService` uses `ReflectionProperty::setAccessible()`;
+     `laminas-cache` uses deprecated `SplObjectStorage::contains/attach/detach`;
+     `phing/phing` (dbdeploy) emits dozens of deprecations. All are E_DEPRECATED (noise,
+     non-fatal) — Melis runs despite them. Even latest (core 5.3.36, installer 5.3.4) are
+     not clean. Composer constraints also still cap at `~8.4` (bypassed by the wizard,
+     which already passes `--ignore-platform-reqs`).
+   - **Trap:** the wizard runs `composer update` mid-install, which **upgrades the Melis
+     packages and overwrites any vendor patch** — so the deprecation fixes must land
+     upstream, not as post-hoc vendor edits.
    See `melisplatform/melis-core#24`.
 7. **PHP 8.5 build gotcha: don't `docker-php-ext-install opcache`** — on 8.5 Zend
    OPcache is built into core (no shared module), so it fails with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ authoritative; scripting it is fragile and was a deliberate non-goal.
 - **Root `Makefile`** wraps the common compose ops: `make up|up-build|down|destroy|
   logs|shell|ps STACK=install|prebuilt|fpm|app/latest`, plus `proxy-up`, `PROXY=1`,
   and `adminer` (DB GUI on :8082). `make help` lists all.
+- **Xdebug** is opt-in in `install/` via `ARG WITH_XDEBUG=1` (`.env` `WITH_XDEBUG=1`):
+  pecl xdebug + config (mode debug,develop; trigger; IDE port 9003). Off by default.
 - **Required PHP extensions:** `pdo_mysql` + `intl` are mandatory, plus
   `mysqli, gd, zip, mbstring, xml, curl, exif, opcache`. `gd` is configured
   `--with-freetype --with-jpeg`; `intl` needs `libicu-dev`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ changes by building/running the relevant stack, not by unit tests.
 | [`install/`](install/) | **Turnkey build**: builds locally, `composer create-project` the skeleton at first run into `./melis` (editable on host) + MySQL. | Devs who want code locally |
 | [`fpm/`](fpm/) | Production-style **nginx + PHP-FPM + MySQL**, skeleton baked into the image. | More production-like topology |
 | [`app/latest/`](app/latest/) | **Legacy** dev path: mounts an existing Melis project (`../../../`) into a PHP-8.3-apache build. | Existing projects |
-| [`dev/`](dev/) | Per-PHP-version **base images** only (no compose). `dev-{apache,fpm}-{8.1,8.2,8.3,8.4}`. | Image building blocks |
+| [`dev/`](dev/) | Per-PHP-version **base images** only (no compose). `dev-{apache,fpm}-{8.1,8.2,8.3,8.4,8.5}`. | Image building blocks |
 | [`local-proxy/`](local-proxy/) | Shared **nginx-proxy** (opt-in) so several stacks share `:80` by hostname. | Running many projects locally |
 
 All paths finish the same way: the **native Melis web installer** at
@@ -65,9 +65,10 @@ authoritative; scripting it is fragile and was a deliberate non-goal.
    mask the baked code. Use the **named volume** `melis-app` (seeded from the image
    on first run). `fpm/clear_env=no` so PHP-FPM sees `getenv(MYSQL_*)`.
 6. **PHP 7.x is incompatible** with current Melis (`require php: ^8.1|^8.3`). PHP
-   **8.4** works via maintained Laminas forks (see `melisplatform/melis-core#24`)
-   and ships as an extra `dev-*-8.4` tag, but `latest` stays on **8.3** (the max
-   version Melis officially lists) until 8.4 is fully released upstream.
+   **8.4 and 8.5** work via maintained Laminas forks (see `melisplatform/melis-core#24`)
+   and ship as extra `dev-*-8.4` / `dev-*-8.5` tags (experimental), but `latest`
+   stays on **8.3** (the max version Melis officially lists) until they are listed
+   upstream.
 
 ## Shared local proxy (opt-in, `local-proxy/` + `*/docker-compose.proxy.yml`)
 
@@ -93,7 +94,7 @@ in the sibling `../melis-platform-website` project. Validate edits with
 
 ## CI (GitHub Actions, all multi-arch `linux/amd64,linux/arm64`)
 
-- **`docker-image.yml`** — builds `dev/` base images, matrix `{apache,fpm} × {8.1..8.4}`,
+- **`docker-image.yml`** — builds `dev/` base images, matrix `{apache,fpm} × {8.1..8.5}`,
   pushes `melisplatform/melis-docker:dev-{variant}-{php}` on `master` only.
 - **`prebuilt-image.yml`** — builds the baked images: `prebuilt/` → `latest`/`php8.3`,
   `fpm/` → `fpm-latest`/`fpm-php8.3`; pushes on `master` pushes and `v*` tags.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,24 @@ authoritative; scripting it is fragile and was a deliberate non-goal.
    on first run). `fpm/clear_env=no` so PHP-FPM sees `getenv(MYSQL_*)`.
 6. **PHP 7.x is incompatible** with current Melis (`require php: ^8.1|^8.3`). **PHP 8.4**
    runs Melis (every dependency allows `~8.4`) and is the experimental ceiling. **PHP 8.5
-   does NOT run Melis yet** (verified 2026-06-13): the skeleton's Laminas deps
-   (laminas-mvc, -servicemanager, -mime, -math, melis-core…) cap at 8.4, so
-   `composer install` fails on 8.5 — at run time for `install/`, at *build* time for
-   `prebuilt/`/`fpm/` (they bake the skeleton). `dev-*-8.5` images build (pure PHP base,
-   forward-looking). `latest` stays on 8.3. See `melisplatform/melis-core#24`.
+   is not usable out of the box yet** — but it's NOT a hard incompatibility (diagnosed
+   end-to-end 2026-06-13). Two distinct blockers:
+   - **Composer constraints:** the skeleton's Laminas deps (laminas-mvc, -servicemanager,
+     -mime, -math, melis-core…) cap at `~8.4`, so a normal `composer install` refuses 8.5
+     — at run time for `install/`, at *build* time for `prebuilt/`/`fpm/` (they bake the
+     skeleton). Bypassable with `composer --ignore-platform-reqs`.
+   - **8.5 deprecation breaks the web installer:** with platform reqs forced, Melis runs,
+     but the installer's DB step fails. Root cause: `melis-installer`
+     `InstallHelperService.php` uses the **deprecated `PDO::MYSQL_ATTR_INIT_COMMAND`**
+     (E_DEPRECATED on 8.5), and `melis-core` (`Module.php` + `config/app.interface.php`)
+     forces `display_errors=1` and `error_reporting = E_ALL & ~E_USER_DEPRECATED` (does
+     NOT exclude core `E_DEPRECATED`). So the deprecation text is printed into the AJAX
+     reply, breaking the JSON the wizard parses — even though the DB check itself returns
+     `success:1`. **Upstream fixes:** (a) use `Pdo\Mysql::ATTR_INIT_COMMAND`; (b) exclude
+     `E_DEPRECATED` / set `display_errors=0`. Patching the constant in-container → clean
+     JSON, verified.
+   `dev-*-8.5` images build (pure PHP base, forward-looking). `latest` stays on 8.3.
+   See `melisplatform/melis-core#24`.
 7. **PHP 8.5 build gotcha: don't `docker-php-ext-install opcache`** — on 8.5 Zend
    OPcache is built into core (no shared module), so it fails with
    `cp: cannot stat 'modules/*'`. All Dockerfiles gate it on `version_compare(...,

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -20,9 +20,10 @@ Source & full docs: **https://github.com/melisplatform/melis-docker**
 | `dev-apache-7.x` | **Legacy** (PHP 7, **not** compatible with current Melis 5.3.x — kept for old projects) |
 
 > **PHP 8.3** is the recommended/default version — `latest` points to it.
-> **PHP 8.4 and 8.5** dev images are available (`dev-{apache,fpm}-8.4`, `dev-{apache,fpm}-8.5`);
-> they rely on maintained Laminas forks and are **experimental** (not yet officially listed by
-> Melis), so `latest` stays on 8.3 for now.
+> **PHP 8.4** is experimental but runs Melis. **PHP 8.5** dev images build, but Melis does
+> **not** run on 8.5 yet — the skeleton's Laminas dependencies cap at 8.4, so its
+> `composer install` fails on 8.5 (the `dev-*-8.5` tags are forward-looking base images).
+> `latest` stays on **8.3**. See melisplatform/melis-core#24.
 
 ## Quick start
 

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -15,13 +15,14 @@ Source & full docs: **https://github.com/melisplatform/melis-docker**
 |-----|-----------|
 | `latest`, `php8.3` | **Pre-built** Melis (Apache + mod_php), skeleton baked in — just add a DB |
 | `fpm-latest`, `fpm-php8.3` | **Pre-built** Melis for an **nginx + PHP-FPM** stack, skeleton baked in |
-| `dev-apache-8.1` … `8.4` | Dev **base** images (PHP + Apache + Composer) to mount your own project |
-| `dev-fpm-8.1` … `8.4` | Dev **base** images (PHP-FPM + Composer) to put behind your own nginx |
+| `dev-apache-8.1` … `8.5` | Dev **base** images (PHP + Apache + Composer) to mount your own project |
+| `dev-fpm-8.1` … `8.5` | Dev **base** images (PHP-FPM + Composer) to put behind your own nginx |
 | `dev-apache-7.x` | **Legacy** (PHP 7, **not** compatible with current Melis 5.3.x — kept for old projects) |
 
 > **PHP 8.3** is the recommended/default version — `latest` points to it.
-> **PHP 8.4** dev images are available (`dev-apache-8.4`, `dev-fpm-8.4`); 8.4 support relies on
-> maintained Laminas forks and is rolling out, so `latest` stays on 8.3 for now.
+> **PHP 8.4 and 8.5** dev images are available (`dev-{apache,fpm}-8.4`, `dev-{apache,fpm}-8.5`);
+> they rely on maintained Laminas forks and are **experimental** (not yet officially listed by
+> Melis), so `latest` stays on 8.3 for now.
 
 ## Quick start
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+# Melis Platform — Docker convenience wrapper.
+# Thin shortcuts over `docker compose` for the four runnable stacks. Pick a stack
+# with STACK=… (default: prebuilt). Examples:
+#
+#   make up                      # start the pre-built stack (pulls the image)
+#   make up STACK=install        # turnkey build (editable code in install/melis)
+#   make up-build STACK=fpm      # build + start the nginx + php-fpm stack
+#   make logs                    # follow logs of the current stack
+#   make shell                   # open a shell in the php container
+#   make down                    # stop (keep data)
+#   make destroy                 # stop + remove volumes (full reset)
+#   make proxy-up / proxy-down   # start/stop the shared local nginx-proxy
+#   make up PROXY=1              # start a stack behind the shared proxy
+#   make adminer / make adminer-stop   # web DB client on http://localhost:8082
+#
+# PHP version is set per stack in its .env (PHP_VERSION=8.3|8.4|8.5) — change it
+# there, then `make up-build`.
+
+STACK ?= prebuilt
+SERVICE ?= php
+# Compose project network the DB sits on (MELIS_CONTAINER_NAME-network; default melis).
+NET ?= melis-network
+
+# Add the opt-in proxy override when PROXY=1
+COMPOSE := docker compose
+ifeq ($(PROXY),1)
+COMPOSE := docker compose -f docker-compose.yml -f docker-compose.proxy.yml
+endif
+
+# Run a compose command inside the selected stack directory
+CC = cd $(STACK) && $(COMPOSE)
+
+.DEFAULT_GOAL := help
+
+.PHONY: help up up-build down destroy restart logs ps shell \
+        proxy-up proxy-down adminer adminer-stop env
+
+help: ## Show this help
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "  Current STACK=$(STACK)  (override: make <target> STACK=install|prebuilt|fpm|app/latest)"
+
+env: ## Create the stack's .env from .env.example if missing
+	@test -f $(STACK)/.env || (cp $(STACK)/.env.example $(STACK)/.env && echo "Created $(STACK)/.env")
+
+up: env ## Start the stack (detached)
+	$(CC) up -d
+
+up-build: env ## Build + start the stack (detached)
+	$(CC) up -d --build
+
+down: ## Stop the stack (keep data)
+	$(CC) down
+
+destroy: ## Stop the stack and remove volumes (full reset)
+	$(CC) down -v
+
+restart: ## Restart the stack
+	$(CC) restart
+
+logs: ## Follow the stack logs
+	$(CC) logs -f
+
+ps: ## Show stack containers
+	$(CC) ps
+
+shell: ## Open a shell in the php container
+	$(CC) exec $(SERVICE) bash || $(CC) exec $(SERVICE) sh
+
+proxy-up: ## Create the webproxy network + start the shared nginx-proxy
+	docker network inspect webproxy >/dev/null 2>&1 || docker network create webproxy
+	docker compose -f local-proxy/docker-compose.yml up -d
+
+proxy-down: ## Stop the shared nginx-proxy
+	docker compose -f local-proxy/docker-compose.yml down
+
+adminer: ## Start Adminer (web DB client) on http://localhost:8082, on network NET
+	docker run --rm -d --name melis-adminer --network $(NET) -p 8082:8080 adminer:4
+	@echo "Adminer → http://localhost:8082  (System: MySQL, Server: <MELIS_CONTAINER_NAME>-db)"
+
+adminer-stop: ## Stop Adminer
+	-docker rm -f melis-adminer

--- a/README.md
+++ b/README.md
@@ -189,6 +189,11 @@ remember to rebuild (`--build`). The pre-built image's version is fixed by its t
 **Connect a DB GUI** — the DB is published on `127.0.0.1:33061` (localhost only), or
 run `make adminer` for a browser client at http://localhost:8082.
 
+**Step-debugging (Xdebug)** — the turnkey [`install/`](install/) stack can bake Xdebug
+in: set `WITH_XDEBUG=1` in `.env` and rebuild (`docker compose up -d --build`). It
+connects back to your IDE on port **9003** and starts on a trigger (browser extension
+or `XDEBUG_TRIGGER`). On Linux the compose file already maps `host.docker.internal`.
+
 **Apache warning `AH00558: … ServerName`** — harmless; the images set
 `ServerName localhost` to silence it.
 

--- a/README.md
+++ b/README.md
@@ -4,67 +4,130 @@ This repository contains Dockerfiles to be used for [Melis Platform](https://www
 
 ## Install Melis with Docker — choose your path
 
-| Path | For whom | Folder |
-|------|----------|--------|
-| **Pre-built image** — pull a ready-to-run Melis (no build) + DB, finish via the web installer | Fastest evaluation / "just run it" | [`prebuilt/`](prebuilt/) |
-| **Turnkey build** — builds a fresh Melis skeleton on your host, editable code in `./melis` | Developers who want the code locally | [`install/`](install/) |
-| **nginx + PHP-FPM** — production-style stack (nginx front, PHP-FPM, MySQL), skeleton baked | A more production-like topology | [`fpm/`](fpm/) |
-| **Dev base images** — mount an existing Melis project, pick a PHP tag (Apache or FPM) | Existing projects | [`app/latest/`](app/latest/) — see *Getting Started* below |
+| Path | What you get | For whom | Folder |
+|------|--------------|----------|--------|
+| **Pre-built image** | Pull a ready-to-run Melis (no build) + MySQL, finish via the web installer | Fastest evaluation / "just run it" | [`prebuilt/`](prebuilt/) |
+| **Turnkey build** | Builds a fresh Melis skeleton on your host, editable code in `./melis`, + MySQL | Developers who want the code locally | [`install/`](install/) |
+| **nginx + PHP-FPM** | Production-style stack (nginx front, PHP-FPM, MySQL), skeleton baked into the image | A more production-like topology | [`fpm/`](fpm/) |
+| **Mount existing project** | Mounts an existing Melis project into a PHP-8.3-apache build | Projects you already have locally | [`app/latest/`](app/latest/) |
+| **Dev base images** | Per-PHP-version base images only (Apache or FPM, PHP 8.1–8.4) | Building your own images | [`dev/`](dev/) |
 
 > All paths finish the same way: the **native Melis web installer** at
-> http://localhost:8080 sets up the DB schema, admin user and the optional demo site.
+> http://localhost:8080 (`/melis/setup`) sets up the DB schema, admin user and the
+> optional demo site. The web installer is authoritative — the install is **not**
+> scripted.
 
 ## Getting Started
 
-> **Important:** This repository should be cloned within your Melis Project root directory.
+Pick one of the paths below. Each folder is self-contained (its own
+`docker-compose.yml`, `.env.example`, `conf/` and `README.md`) — see that folder's
+README for full details.
 
-### Clone project
+> **Note:** Make sure host port **8080** is free (change `HOST_PORT` in `.env` if not).
+
+### Clone the repository
 ```bash
 git clone https://github.com/melisplatform/melis-docker.git
 ```
 
-> **Note:** Make sure that port 8080 is not used on your host. You can change it in the *.env* file if needed.
-
-### Build and Run
-
-#### Windows Users
-You can use the provided batch file to start Docker:
+### Path A — Pre-built image (fastest)
+Runs the published image + a MySQL service. No build on your machine.
 ```bash
-start-docker.bat
+cd melis-docker/prebuilt
+cp .env.example .env
+docker compose up -d
 ```
 
-#### Manual Build
+### Path B — Turnkey build (editable code on your host)
+First run does `composer create-project` of the Melis skeleton into `./melis`
+(takes a few minutes); the code stays on your host, editable.
 ```bash
-cd melis-docker/app/latest && docker-compose up --build
+cd melis-docker/install
+cp .env.example .env
+docker compose up --build
 ```
 
-### Start Stack
+### Path C — nginx + PHP-FPM (production-style)
 ```bash
-docker-compose up -d
+cd melis-docker/fpm
+cp .env.example .env
+docker compose up --build
 ```
 
-### Access the Platform
-Open your favorite browser and navigate to: http://localhost:8080
-
-### Shutdown Stack
+### Path D — Mount an existing Melis project
+Clone this repo **inside your Melis project root**, then:
 ```bash
-docker-compose down -v
+cd melis-docker/app/latest
+cp .env.example .env
+docker compose up --build
+```
+> **Windows:** a `start-docker.bat` helper is provided at the repo root for this path.
+
+### Finish the install
+Open http://localhost:8080 and follow the **Melis web installer**. When it asks for
+the database, use the values from your `.env`:
+
+| Field | Value |
+|-------|-------|
+| Host | `melis-db` &nbsp;*(no `:port`)* |
+| Database / User / Password | `melis` / `melis` / `melis` |
+
+### Stop a stack
+```bash
+docker compose down       # keep data
+docker compose down -v    # also remove volumes (DB + app), full reset
 ```
 
-### Build Components
+## Run several projects at once (shared local proxy)
 
-#### Configuration
-Change PHP version in **app/latest/.env** (default **dev-apache-8.3**)
+Each stack publishes a host port (`8080` by default), so running several at once
+means juggling port numbers. To avoid that — and any `:80` clash with other local
+Docker projects — there's an **opt-in** shared reverse proxy in
+[`local-proxy/`](local-proxy/) ([`nginxproxy/nginx-proxy`](https://github.com/nginx-proxy/nginx-proxy)).
+It owns `:80` and routes by hostname; each stack declares a `VIRTUAL_HOST` and the
+per-stack `docker-compose.proxy.yml` override drops its published port.
 
-Available tags (PHP versions shipped in [`dev/`](dev/)) — [View on Docker Hub](https://hub.docker.com/repository/docker/melisplatform/melis-docker):
+```bash
+# 1) Once: create the shared network and start the proxy
+docker network create webproxy
+docker compose -f local-proxy/docker-compose.yml up -d
 
-Apache (`mod_php`) — `dev-apache-8.1`, `dev-apache-8.2`, **`dev-apache-8.3`** (recommended), `dev-apache-8.4`
-PHP-FPM — `dev-fpm-8.1`, `dev-fpm-8.2`, `dev-fpm-8.3`, `dev-fpm-8.4`
+# 2) Map the *.local hostnames to localhost (one line in /etc/hosts)
+#    127.0.0.1  melis-prebuilt.local melis-install.local melis-fpm.local melis-app.local
 
-> **PHP 8.3** is the recommended/default version (officially supported by Melis 5.3.x).
+# 3) Bring up any stack WITH its proxy override (note the two -f flags)
+cd prebuilt
+cp .env.example .env
+docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d
+# → http://melis-prebuilt.local/   (no host port needed)
+```
+
+Default hostnames: `melis-prebuilt.local`, `melis-install.local`, `melis-fpm.local`,
+`melis-app.local` — override any via `VIRTUAL_HOST` in that stack's `.env`. To run
+**several stacks simultaneously**, also give each a distinct `MELIS_CONTAINER_NAME`
+so container names don't collide.
+
+> Without the `-f docker-compose.proxy.yml` flag every stack runs exactly as before
+> (published on `HOST_PORT`) — the proxy is purely opt-in.
+
+## Published image tags
+
+[View on Docker Hub →](https://hub.docker.com/r/melisplatform/melis-docker)
+
+**Pre-built (skeleton baked):**
+- Apache (`mod_php`): `latest`, `php8.3`
+- nginx + PHP-FPM: `fpm-latest`, `fpm-php8.3`
+
+**Dev base images** (no app, just the PHP stack) — published from [`dev/`](dev/):
+- Apache (`mod_php`): `dev-apache-8.1`, `dev-apache-8.2`, **`dev-apache-8.3`** (recommended), `dev-apache-8.4`
+- PHP-FPM: `dev-fpm-8.1`, `dev-fpm-8.2`, `dev-fpm-8.3`, `dev-fpm-8.4`
+
+> **PHP 8.3** is the default/recommended version (officially supported by Melis 5.3.x).
 > **PHP 8.4** works via the maintained Laminas forks (see melisplatform/melis-core#24);
 > it ships as an additional tag — `latest` stays on 8.3 until 8.4 is fully released
-> upstream. The old `dev-apache-7.x` tags are **not compatible** with current Melis.
+> upstream. The old PHP **7.x** tags are **not compatible** with current Melis.
+
+All images are multi-arch (`linux/amd64`, `linux/arm64`).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -123,12 +123,74 @@ so container names don't collide.
 - PHP-FPM: `dev-fpm-8.1`, `dev-fpm-8.2`, `dev-fpm-8.3`, `dev-fpm-8.4`, `dev-fpm-8.5`
 
 > **PHP 8.3** is the default/recommended version (officially supported by Melis 5.3.x).
-> **PHP 8.4 and 8.5** work via the maintained Laminas forks (see melisplatform/melis-core#24)
-> and ship as additional, **experimental** tags — `latest` stays on 8.3 until they are
-> officially listed upstream. The old PHP **7.x** tags are **not compatible** with current Melis.
+> **PHP 8.4** is experimental but runs Melis (every dependency allows it). **PHP 8.5**
+> base images build, but Melis does **not** run on 8.5 yet — the skeleton's Laminas
+> dependencies cap at 8.4, so its `composer install` fails on 8.5. The `dev-*-8.5` tags
+> are forward-looking (standalone PHP base) until upstream lifts the cap (see
+> melisplatform/melis-core#24). `latest` stays on 8.3. The old PHP **7.x** tags are
+> **not compatible** with current Melis.
 
 All images are multi-arch (`linux/amd64`, `linux/arm64`).
 
+## Choosing the PHP version
+
+The buildable stacks (`install/`, `prebuilt/`, `fpm/`) default to **PHP 8.3**. To
+build on another version, set `PHP_VERSION` in that stack's `.env` and rebuild:
+
+```bash
+cd install
+echo "PHP_VERSION=8.4" >> .env     # 8.3 (default, recommended) | 8.4 (experimental)
+docker compose up -d --build
+```
+
+> **8.4** is experimental but installs and runs Melis. **8.5 is not usable for Melis
+> yet**: the skeleton's Laminas dependencies cap at 8.4, so `composer install` fails on
+> 8.5 (it fails at run time for `install/`, and at *build* time for `prebuilt/`/`fpm/`
+> which bake the skeleton). Use **8.3 or 8.4** to actually run Melis. The standalone
+> `dev-*-8.5` base images do build — they're forward-looking. See melis-core#24.
+
+## Handy shortcuts (Makefile)
+
+A root [`Makefile`](Makefile) wraps the common `docker compose` calls. Pick a stack
+with `STACK=…` (default `prebuilt`):
+
+```bash
+make up STACK=install     # cp .env + start (turnkey build)
+make up-build STACK=fpm   # build + start the nginx + php-fpm stack
+make logs                 # follow logs        make shell    # shell into php
+make down                 # stop (keep data)   make destroy  # stop + wipe volumes
+make proxy-up             # shared nginx-proxy  make up PROXY=1  # run a stack behind it
+make adminer              # web DB client → http://localhost:8082
+make help                 # list everything
+```
+
+## Troubleshooting / FAQ
+
+**Port 8080 already in use** — change `HOST_PORT` in the stack's `.env`, or run
+behind the [shared proxy](#run-several-projects-at-once-shared-local-proxy) and
+drop host ports entirely.
+
+**"Test database connection" fails in the web installer** — enter the DB **host
+without a port** (e.g. `melis-db`, *not* `melis-db:3306`); a `host:port` value
+breaks Melis' flyway/JDBC URL. Credentials are whatever you set in `.env`
+(defaults `melis` / `melis` / `melis`). The DB must use collation
+`utf8mb4_general_ci` (these compose files already do).
+
+**The page won't load on first start** — the first run downloads the Melis skeleton
+(turnkey) or seeds the app volume (pre-built) before Apache/nginx answers; give it
+a minute. Follow progress with `make logs` (or `docker compose logs -f`).
+
+**Reset everything and start fresh** — `make destroy` (or `docker compose down -v`).
+For the turnkey stack also delete the host code: `rm -rf install/melis`.
+
+**Switch PHP version** — see [Choosing the PHP version](#choosing-the-php-version);
+remember to rebuild (`--build`). The pre-built image's version is fixed by its tag.
+
+**Connect a DB GUI** — the DB is published on `127.0.0.1:33061` (localhost only), or
+run `make adminer` for a browser client at http://localhost:8082.
+
+**Apache warning `AH00558: … ServerName`** — harmless; the images set
+`ServerName localhost` to silence it.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains Dockerfiles to be used for [Melis Platform](https://www
 | **Turnkey build** | Builds a fresh Melis skeleton on your host, editable code in `./melis`, + MySQL | Developers who want the code locally | [`install/`](install/) |
 | **nginx + PHP-FPM** | Production-style stack (nginx front, PHP-FPM, MySQL), skeleton baked into the image | A more production-like topology | [`fpm/`](fpm/) |
 | **Mount existing project** | Mounts an existing Melis project into a PHP-8.3-apache build | Projects you already have locally | [`app/latest/`](app/latest/) |
-| **Dev base images** | Per-PHP-version base images only (Apache or FPM, PHP 8.1–8.4) | Building your own images | [`dev/`](dev/) |
+| **Dev base images** | Per-PHP-version base images only (Apache or FPM, PHP 8.1–8.5) | Building your own images | [`dev/`](dev/) |
 
 > All paths finish the same way: the **native Melis web installer** at
 > http://localhost:8080 (`/melis/setup`) sets up the DB schema, admin user and the
@@ -119,13 +119,13 @@ so container names don't collide.
 - nginx + PHP-FPM: `fpm-latest`, `fpm-php8.3`
 
 **Dev base images** (no app, just the PHP stack) — published from [`dev/`](dev/):
-- Apache (`mod_php`): `dev-apache-8.1`, `dev-apache-8.2`, **`dev-apache-8.3`** (recommended), `dev-apache-8.4`
-- PHP-FPM: `dev-fpm-8.1`, `dev-fpm-8.2`, `dev-fpm-8.3`, `dev-fpm-8.4`
+- Apache (`mod_php`): `dev-apache-8.1`, `dev-apache-8.2`, **`dev-apache-8.3`** (recommended), `dev-apache-8.4`, `dev-apache-8.5`
+- PHP-FPM: `dev-fpm-8.1`, `dev-fpm-8.2`, `dev-fpm-8.3`, `dev-fpm-8.4`, `dev-fpm-8.5`
 
 > **PHP 8.3** is the default/recommended version (officially supported by Melis 5.3.x).
-> **PHP 8.4** works via the maintained Laminas forks (see melisplatform/melis-core#24);
-> it ships as an additional tag — `latest` stays on 8.3 until 8.4 is fully released
-> upstream. The old PHP **7.x** tags are **not compatible** with current Melis.
+> **PHP 8.4 and 8.5** work via the maintained Laminas forks (see melisplatform/melis-core#24)
+> and ship as additional, **experimental** tags — `latest` stays on 8.3 until they are
+> officially listed upstream. The old PHP **7.x** tags are **not compatible** with current Melis.
 
 All images are multi-arch (`linux/amd64`, `linux/arm64`).
 

--- a/app/latest/.env.example
+++ b/app/latest/.env.example
@@ -11,3 +11,7 @@ MYSQL_HOST=db
 MYSQL_DATABASE=melis-dev
 MYSQL_USER=melis
 MYSQL_PASSWORD=root
+
+# Optional — only when running behind the shared local nginx-proxy
+# (docker-compose.proxy.yml). Hostname this stack answers to; the host port is dropped.
+# VIRTUAL_HOST=melis-app.local

--- a/app/latest/docker-compose.proxy.yml
+++ b/app/latest/docker-compose.proxy.yml
@@ -1,0 +1,24 @@
+# Opt-in: run this stack behind the shared local nginx-proxy (see ../../local-proxy).
+# Drops the published host port and exposes the app to the proxy via VIRTUAL_HOST.
+#
+#   docker network create webproxy                          # once
+#   docker compose -f ../../local-proxy/docker-compose.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d --build
+#   # → http://${VIRTUAL_HOST:-melis-app.local}/   (add it to /etc/hosts → 127.0.0.1)
+#
+# Running several Melis stacks at once? Give each its own MELIS_CONTAINER_NAME and
+# VIRTUAL_HOST in its .env so container names and hostnames don't collide.
+services:
+  php:
+    # Remove the "8080:80" mapping from the base file — access is via the proxy.
+    ports: !reset []
+    environment:
+      VIRTUAL_HOST: ${VIRTUAL_HOST:-melis-app.local}
+      VIRTUAL_PORT: "80"
+    networks:
+      - melis
+      - webproxy
+
+networks:
+  webproxy:
+    external: true

--- a/dev/php-apache-8.5/Dockerfile
+++ b/dev/php-apache-8.5/Dockerfile
@@ -1,0 +1,35 @@
+# Melis Platform — dev base image (PHP 8.5 + Apache + Composer)
+# A ready-to-use PHP/Apache base with the extensions Melis needs. Mount your Melis
+# project into the container (see app/latest/ for a full local dev stack).
+# Build: docker build -t melisplatform/melis-docker:dev-apache-8.5 .
+#
+# NOTE: PHP 8.5 is experimental for Melis — it satisfies the composer `^8.1`
+# constraint and builds on the maintained Laminas forks (see melis-core#24), but
+# is not yet officially listed by Melis. `latest` stays on 8.3.
+FROM php:8.5-apache
+
+ARG TZ=Europe/Paris
+ENV TZ=${TZ}
+
+# System packages + PHP extensions required by Melis (intl needs libicu-dev)
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git unzip curl wget vim \
+        default-mysql-client \
+        libxml2-dev libonig-dev libcurl4-gnutls-dev libzip-dev \
+        libjpeg-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libpng-dev \
+        libicu-dev tzdata \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    # NOTE: opcache is omitted here — on PHP 8.5 Zend OPcache is built into core
+    # (already loaded, no shared module), so docker-php-ext-install opcache fails.
+    && docker-php-ext-install -j"$(nproc)" \
+        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif \
+    && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
+    && rm -rf /var/lib/apt/lists/*
+
+# Composer (official image) + Apache modules Melis relies on
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+RUN a2enmod rewrite headers
+
+EXPOSE 80
+CMD ["apache2-foreground"]

--- a/dev/php-apache-8.5/Dockerfile
+++ b/dev/php-apache-8.5/Dockerfile
@@ -3,9 +3,10 @@
 # project into the container (see app/latest/ for a full local dev stack).
 # Build: docker build -t melisplatform/melis-docker:dev-apache-8.5 .
 #
-# NOTE: PHP 8.5 is experimental for Melis — it satisfies the composer `^8.1`
-# constraint and builds on the maintained Laminas forks (see melis-core#24), but
-# is not yet officially listed by Melis. `latest` stays on 8.3.
+# NOTE: This is a valid PHP 8.5 base image, but **Melis does not run on 8.5 yet** —
+# the skeleton's Laminas dependencies cap at PHP 8.4, so `composer install` fails on
+# 8.5. Provided as a forward-looking / standalone PHP base until upstream lifts the
+# cap (see melis-core#24). To actually run Melis use 8.3 (default) or 8.4.
 FROM php:8.5-apache
 
 ARG TZ=Europe/Paris

--- a/dev/php-fpm-8.5/Dockerfile
+++ b/dev/php-fpm-8.5/Dockerfile
@@ -3,9 +3,10 @@
 # (e.g. nginx) in front — see fpm/ for a ready-to-run nginx + php-fpm stack.
 # Build: docker build -t melisplatform/melis-docker:dev-fpm-8.5 .
 #
-# NOTE: PHP 8.5 is experimental for Melis — it satisfies the composer `^8.1`
-# constraint and builds on the maintained Laminas forks (see melis-core#24), but
-# is not yet officially listed by Melis. `latest` stays on 8.3.
+# NOTE: This is a valid PHP 8.5 base image, but **Melis does not run on 8.5 yet** —
+# the skeleton's Laminas dependencies cap at PHP 8.4, so `composer install` fails on
+# 8.5. Provided as a forward-looking / standalone PHP base until upstream lifts the
+# cap (see melis-core#24). To actually run Melis use 8.3 (default) or 8.4.
 FROM php:8.5-fpm
 
 ARG TZ=Europe/Paris

--- a/dev/php-fpm-8.5/Dockerfile
+++ b/dev/php-fpm-8.5/Dockerfile
@@ -1,0 +1,34 @@
+# Melis Platform — dev base image (PHP 8.5 FPM + Composer)
+# PHP-FPM base with the extensions Melis needs (listens on :9000). Put a web server
+# (e.g. nginx) in front — see fpm/ for a ready-to-run nginx + php-fpm stack.
+# Build: docker build -t melisplatform/melis-docker:dev-fpm-8.5 .
+#
+# NOTE: PHP 8.5 is experimental for Melis — it satisfies the composer `^8.1`
+# constraint and builds on the maintained Laminas forks (see melis-core#24), but
+# is not yet officially listed by Melis. `latest` stays on 8.3.
+FROM php:8.5-fpm
+
+ARG TZ=Europe/Paris
+ENV TZ=${TZ}
+
+# System packages + PHP extensions required by Melis (intl needs libicu-dev)
+RUN apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git unzip curl wget vim \
+        default-mysql-client \
+        libxml2-dev libonig-dev libcurl4-gnutls-dev libzip-dev \
+        libjpeg-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libpng-dev \
+        libicu-dev tzdata \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    # NOTE: opcache is omitted here — on PHP 8.5 Zend OPcache is built into core
+    # (already loaded, no shared module), so docker-php-ext-install opcache fails.
+    && docker-php-ext-install -j"$(nproc)" \
+        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif \
+    && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
+    && rm -rf /var/lib/apt/lists/*
+
+# Composer (official image)
+COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+
+EXPOSE 9000
+CMD ["php-fpm"]

--- a/fpm/.env.example
+++ b/fpm/.env.example
@@ -11,6 +11,10 @@ MELIS_PLATFORM=local
 MELIS_MODULE=MySite
 TZ=Europe/Paris
 
+# PHP version of the built image. 8.3 = default/recommended (officially supported).
+# 8.4 and 8.5 are experimental (maintained Laminas forks). Change → rebuild (--build).
+PHP_VERSION=8.3
+
 # Ports (host side)
 HOST_PORT=8080
 DB_HOST_PORT=33061

--- a/fpm/.env.example
+++ b/fpm/.env.example
@@ -15,6 +15,10 @@ TZ=Europe/Paris
 HOST_PORT=8080
 DB_HOST_PORT=33061
 
+# Optional — only when running behind the shared local nginx-proxy
+# (docker-compose.proxy.yml). Hostname this stack answers to; HOST_PORT is dropped.
+# VIRTUAL_HOST=melis-fpm.local
+
 # Database (these are the credentials to enter in the Melis web installer)
 MYSQL_VERSION=8.4
 MYSQL_DATABASE=melis

--- a/fpm/.env.example
+++ b/fpm/.env.example
@@ -12,7 +12,8 @@ MELIS_MODULE=MySite
 TZ=Europe/Paris
 
 # PHP version of the built image. 8.3 = default/recommended (officially supported).
-# 8.4 and 8.5 are experimental (maintained Laminas forks). Change → rebuild (--build).
+# 8.4 = experimental but runs Melis. 8.5 is NOT usable yet (Laminas deps cap at 8.4
+# → Melis composer install fails). Change → rebuild (--build).
 PHP_VERSION=8.3
 
 # Ports (host side)

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -42,6 +42,12 @@ RUN apt-get update -y \
 # Composer (kept at runtime: the web installer adds modules via composer)
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
+# Clone public github repos over HTTPS instead of SSH (the image has no ssh client
+# or keys). Needed when Composer resolves the public melisplatform Laminas forks
+# from their VCS source — e.g. on PHP 8.5, where the locked dist versions can't be
+# used. No-op for 8.3/8.4 (which install from dist). Public repos → no credentials.
+RUN git config --system url."https://github.com/".insteadOf "git@github.com:"
+
 # PHP + FPM pool config (clear_env=no so PHP sees the container's MYSQL_*/MELIS_* vars)
 COPY ./conf/php.ini /usr/local/etc/php/conf.d/php-melis.ini
 COPY ./conf/www.conf /usr/local/etc/php-fpm.d/zz-melis.conf

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -5,8 +5,10 @@
 # DB schema / admin / optional demo are still set up via the Melis web installer.
 #
 # PHP version is configurable: default 8.3 (officially supported by Melis 5.3.x).
-# Override with --build-arg PHP_VERSION=8.4|8.5 (or PHP_VERSION in .env via compose);
-# 8.4/8.5 are experimental (maintained Laminas forks, see melis-core#24).
+# Override with --build-arg PHP_VERSION=8.4 (or PHP_VERSION in .env via compose).
+# 8.4 is experimental but runs Melis. 8.5 is NOT usable yet: the skeleton's Laminas
+# deps cap at 8.4, so the create-project step below FAILS the build on 8.5
+# (see melis-core#24).
 ARG PHP_VERSION=8.3
 FROM php:${PHP_VERSION}-fpm
 

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -3,7 +3,12 @@
 # front (see docker-compose.yml). The Melis skeleton is BAKED at build time, like
 # prebuilt/, so the image is self-contained; only a database is needed at run time.
 # DB schema / admin / optional demo are still set up via the Melis web installer.
-FROM php:8.3-fpm
+#
+# PHP version is configurable: default 8.3 (officially supported by Melis 5.3.x).
+# Override with --build-arg PHP_VERSION=8.4|8.5 (or PHP_VERSION in .env via compose);
+# 8.4/8.5 are experimental (maintained Laminas forks, see melis-core#24).
+ARG PHP_VERSION=8.3
+FROM php:${PHP_VERSION}-fpm
 
 ARG APP_NAME=melis
 ARG TZ=Europe/Paris
@@ -24,8 +29,11 @@ RUN apt-get update -y \
         libjpeg-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libpng-dev \
         libicu-dev tzdata \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    # opcache: built into core on PHP 8.5+ (not a shared module), so only install
+    # it on < 8.5. Detected at build time → works for any PHP_VERSION.
+    && OPCACHE=$(php -r 'echo version_compare(PHP_VERSION, "8.5", "<") ? "opcache" : "";') \
     && docker-php-ext-install -j"$(nproc)" \
-        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif opcache \
+        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif $OPCACHE \
     && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
     && rm -rf /var/lib/apt/lists/*
 

--- a/fpm/conf/php.ini
+++ b/fpm/conf/php.ini
@@ -7,6 +7,14 @@ post_max_size = 64M
 date.timezone = Europe/Paris
 expose_php = Off
 
+; Don't render PHP errors into HTTP output — log them instead. This keeps AJAX/JSON
+; responses clean (PHP 8.5 emits many deprecations from Melis/Laminas/phing code;
+; if displayed they pollute installer AJAX and clutter the back-office). Errors are
+; still captured via `docker compose logs`.
+display_errors = Off
+log_errors = On
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
+
 opcache.enable = 1
 opcache.memory_consumption = 192
 opcache.max_accelerated_files = 20000

--- a/fpm/docker-compose.proxy.yml
+++ b/fpm/docker-compose.proxy.yml
@@ -1,0 +1,24 @@
+# Opt-in: run this stack behind the shared local nginx-proxy (see ../local-proxy).
+# Here the proxy targets the nginx "web" service (php is FPM-only, internal).
+#
+#   docker network create webproxy                          # once
+#   docker compose -f ../local-proxy/docker-compose.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d --build
+#   # → http://${VIRTUAL_HOST:-melis-fpm.local}/   (add it to /etc/hosts → 127.0.0.1)
+#
+# Running several Melis stacks at once? Give each its own MELIS_CONTAINER_NAME and
+# VIRTUAL_HOST in its .env so container names and hostnames don't collide.
+services:
+  web:
+    # Remove the "8080:80" mapping from the base file — access is via the proxy.
+    ports: !reset []
+    environment:
+      VIRTUAL_HOST: ${VIRTUAL_HOST:-melis-fpm.local}
+      VIRTUAL_PORT: "80"
+    networks:
+      - melis
+      - webproxy
+
+networks:
+  webproxy:
+    external: true

--- a/fpm/docker-compose.yml
+++ b/fpm/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       args:
         APP_NAME: ${APP_NAME:-melis}
         TZ: ${TZ:-Europe/Paris}
+        PHP_VERSION: ${PHP_VERSION:-8.3}
     image: ${MELIS_FPM_IMAGE:-melisplatform/melis-docker:fpm-php8.3}
     container_name: ${MELIS_CONTAINER_NAME:-melis}-php
     depends_on:

--- a/install/.env.example
+++ b/install/.env.example
@@ -12,6 +12,9 @@ TZ=Europe/Paris
 # → Melis composer install fails). Change → rebuild (--build).
 PHP_VERSION=8.3
 
+# Step-debugging: set to 1 to bake Xdebug into the image (IDE port 9003). Rebuild.
+WITH_XDEBUG=0
+
 # Ports (host side)
 HOST_PORT=8080
 DB_HOST_PORT=33061

--- a/install/.env.example
+++ b/install/.env.example
@@ -11,6 +11,10 @@ TZ=Europe/Paris
 HOST_PORT=8080
 DB_HOST_PORT=33061
 
+# Optional — only when running behind the shared local nginx-proxy
+# (docker-compose.proxy.yml). Hostname this stack answers to; HOST_PORT is dropped.
+# VIRTUAL_HOST=melis-install.local
+
 # Database (these are the credentials to enter in the Melis web installer)
 MYSQL_VERSION=8.4
 MYSQL_DATABASE=melis

--- a/install/.env.example
+++ b/install/.env.example
@@ -8,7 +8,8 @@ MELIS_MODULE=MySite
 TZ=Europe/Paris
 
 # PHP version of the built image. 8.3 = default/recommended (officially supported).
-# 8.4 and 8.5 are experimental (maintained Laminas forks). Change → rebuild (--build).
+# 8.4 = experimental but runs Melis. 8.5 is NOT usable yet (Laminas deps cap at 8.4
+# → Melis composer install fails). Change → rebuild (--build).
 PHP_VERSION=8.3
 
 # Ports (host side)

--- a/install/.env.example
+++ b/install/.env.example
@@ -7,6 +7,10 @@ MELIS_PLATFORM=local
 MELIS_MODULE=MySite
 TZ=Europe/Paris
 
+# PHP version of the built image. 8.3 = default/recommended (officially supported).
+# 8.4 and 8.5 are experimental (maintained Laminas forks). Change → rebuild (--build).
+PHP_VERSION=8.3
+
 # Ports (host side)
 HOST_PORT=8080
 DB_HOST_PORT=33061

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -34,6 +34,22 @@ RUN apt-get update -y && apt-get upgrade -y \
     && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
     && rm -rf /var/lib/apt/lists/*
 
+# Optional Xdebug for step-debugging — opt-in (off by default to keep it lean).
+# Enable with --build-arg WITH_XDEBUG=1 (or WITH_XDEBUG=1 in .env via compose).
+# Defaults: connects back to your IDE on port 9003; on Linux add to the php service
+#   extra_hosts: ["host.docker.internal:host-gateway"]
+ARG WITH_XDEBUG=0
+RUN if [ "$WITH_XDEBUG" = "1" ]; then \
+        pecl install xdebug && docker-php-ext-enable xdebug \
+        && { \
+            echo "xdebug.mode=debug,develop"; \
+            echo "xdebug.start_with_request=trigger"; \
+            echo "xdebug.client_host=host.docker.internal"; \
+            echo "xdebug.client_port=9003"; \
+            echo "xdebug.discover_client_host=true"; \
+        } > /usr/local/etc/php/conf.d/zz-xdebug.ini ; \
+    fi
+
 # Composer (needed at runtime: skeleton bootstrap + the web installer adds modules)
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -53,6 +53,12 @@ RUN if [ "$WITH_XDEBUG" = "1" ]; then \
 # Composer (needed at runtime: skeleton bootstrap + the web installer adds modules)
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
+# Clone public github repos over HTTPS instead of SSH (the image has no ssh client
+# or keys). Needed when Composer resolves the public melisplatform Laminas forks
+# from their VCS source — e.g. on PHP 8.5, where the locked dist versions can't be
+# used. No-op for 8.3/8.4 (which install from dist). Public repos → no credentials.
+RUN git config --system url."https://github.com/".insteadOf "git@github.com:"
+
 # Apache: serve Melis from /public, enable rewrite
 COPY ./conf/vhost.conf /etc/apache2/sites-available/000-default.conf
 COPY ./conf/php.ini /usr/local/etc/php/conf.d/php-melis.ini

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -3,8 +3,10 @@
 # handles DB schema, admin user and the optional demo site.
 #
 # PHP version is configurable: default 8.3 (officially supported by Melis 5.3.x).
-# Override with --build-arg PHP_VERSION=8.4|8.5 (or PHP_VERSION in .env via compose);
-# 8.4/8.5 are experimental (maintained Laminas forks, see melis-core#24).
+# Override with --build-arg PHP_VERSION=8.4 (or PHP_VERSION in .env via compose).
+# 8.4 is experimental but runs Melis. 8.5 is NOT usable yet: this image builds, but
+# the skeleton's Laminas deps cap at 8.4, so composer install fails at run time
+# (see melis-core#24).
 ARG PHP_VERSION=8.3
 FROM php:${PHP_VERSION}-apache
 

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,7 +1,12 @@
-# Melis Platform — turnkey install image (PHP 8.3 + Apache + Composer)
+# Melis Platform — turnkey install image (Apache + Composer)
 # Boots a fresh Melis skeleton on first run; the Melis web installer then
 # handles DB schema, admin user and the optional demo site.
-FROM php:8.3-apache
+#
+# PHP version is configurable: default 8.3 (officially supported by Melis 5.3.x).
+# Override with --build-arg PHP_VERSION=8.4|8.5 (or PHP_VERSION in .env via compose);
+# 8.4/8.5 are experimental (maintained Laminas forks, see melis-core#24).
+ARG PHP_VERSION=8.3
+FROM php:${PHP_VERSION}-apache
 
 ARG APP_NAME=melis
 ARG TZ=Europe/Paris
@@ -19,8 +24,11 @@ RUN apt-get update -y && apt-get upgrade -y \
         libjpeg-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libpng-dev \
         libicu-dev tzdata \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    # opcache: built into core on PHP 8.5+ (not a shared module), so only install
+    # it on < 8.5. Detected at build time → works for any PHP_VERSION.
+    && OPCACHE=$(php -r 'echo version_compare(PHP_VERSION, "8.5", "<") ? "opcache" : "";') \
     && docker-php-ext-install -j"$(nproc)" \
-        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif opcache \
+        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif $OPCACHE \
     && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
     && rm -rf /var/lib/apt/lists/*
 

--- a/install/conf/php.ini
+++ b/install/conf/php.ini
@@ -7,6 +7,14 @@ post_max_size = 64M
 date.timezone = Europe/Paris
 expose_php = Off
 
+; Don't render PHP errors into HTTP output — log them instead. This keeps AJAX/JSON
+; responses clean (PHP 8.5 emits many deprecations from Melis/Laminas/phing code;
+; if displayed they pollute installer AJAX and clutter the back-office). Errors are
+; still captured via `docker compose logs`.
+display_errors = Off
+log_errors = On
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
+
 opcache.enable = 1
 opcache.memory_consumption = 192
 opcache.max_accelerated_files = 20000

--- a/install/docker-compose.proxy.yml
+++ b/install/docker-compose.proxy.yml
@@ -1,0 +1,24 @@
+# Opt-in: run this stack behind the shared local nginx-proxy (see ../local-proxy).
+# Drops the published host port and exposes the app to the proxy via VIRTUAL_HOST.
+#
+#   docker network create webproxy                          # once
+#   docker compose -f ../local-proxy/docker-compose.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d --build
+#   # → http://${VIRTUAL_HOST:-melis-install.local}/   (add it to /etc/hosts → 127.0.0.1)
+#
+# Running several Melis stacks at once? Give each its own MELIS_CONTAINER_NAME and
+# VIRTUAL_HOST in its .env so container names and hostnames don't collide.
+services:
+  php:
+    # Remove the "8080:80" mapping from the base file — access is via the proxy.
+    ports: !reset []
+    environment:
+      VIRTUAL_HOST: ${VIRTUAL_HOST:-melis-install.local}
+      VIRTUAL_PORT: "80"
+    networks:
+      - melis
+      - webproxy
+
+networks:
+  webproxy:
+    external: true

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       args:
         APP_NAME: ${APP_NAME:-melis}
         TZ: ${TZ:-Europe/Paris}
+        PHP_VERSION: ${PHP_VERSION:-8.3}
     container_name: ${MELIS_CONTAINER_NAME:-melis}-php
     depends_on:
       db:

--- a/install/docker-compose.yml
+++ b/install/docker-compose.yml
@@ -11,7 +11,11 @@ services:
         APP_NAME: ${APP_NAME:-melis}
         TZ: ${TZ:-Europe/Paris}
         PHP_VERSION: ${PHP_VERSION:-8.3}
+        WITH_XDEBUG: ${WITH_XDEBUG:-0}
     container_name: ${MELIS_CONTAINER_NAME:-melis}-php
+    # On Linux, let Xdebug reach your IDE on the host (no-op on macOS/Windows):
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       db:
         condition: service_healthy

--- a/local-proxy/docker-compose.yml
+++ b/local-proxy/docker-compose.yml
@@ -1,0 +1,30 @@
+# Shared local reverse-proxy for all *.local Melis projects.
+# Listens on :80 and routes by domain name (the VIRTUAL_HOST env of each
+# container). Every project joins the external "webproxy" network and declares
+# VIRTUAL_HOST — then it's reachable at http://<that-host>/ with no per-project
+# host port to remember and no :80 clash between projects.
+#
+#   docker network create webproxy                          # once, shared by all projects
+#   docker compose -f local-proxy/docker-compose.yml up -d  # start the proxy
+#
+# Then bring up any stack with its proxy override, e.g.:
+#   cd prebuilt && docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d
+#
+# Map the *.local hostnames to 127.0.0.1 in /etc/hosts (or use a wildcard
+# resolver like dnsmasq), e.g.:
+#   127.0.0.1  melis-prebuilt.local melis-install.local melis-fpm.local melis-app.local
+services:
+  nginx-proxy:
+    image: nginxproxy/nginx-proxy:1.6
+    container_name: local-nginx-proxy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    networks:
+      - webproxy
+
+networks:
+  webproxy:
+    external: true

--- a/prebuilt/.env.example
+++ b/prebuilt/.env.example
@@ -15,6 +15,10 @@ TZ=Europe/Paris
 HOST_PORT=8080
 DB_HOST_PORT=33061
 
+# Optional — only when running behind the shared local nginx-proxy
+# (docker-compose.proxy.yml). Hostname this stack answers to; HOST_PORT is dropped.
+# VIRTUAL_HOST=melis-prebuilt.local
+
 # Database (these are the credentials to enter in the Melis web installer)
 MYSQL_VERSION=8.4
 MYSQL_DATABASE=melis

--- a/prebuilt/.env.example
+++ b/prebuilt/.env.example
@@ -4,6 +4,10 @@
 #   melisplatform/melis-docker:php8.3   or   :latest
 MELIS_IMAGE=melisplatform/melis-docker:latest
 
+# Only if you BUILD locally (uncomment the build: block in docker-compose.yml):
+# PHP version of the image. 8.3 = default | 8.4 | 8.5 (experimental).
+# PHP_VERSION=8.3
+
 # App
 APP_NAME=melis
 MELIS_CONTAINER_NAME=melis

--- a/prebuilt/.env.example
+++ b/prebuilt/.env.example
@@ -5,7 +5,8 @@
 MELIS_IMAGE=melisplatform/melis-docker:latest
 
 # Only if you BUILD locally (uncomment the build: block in docker-compose.yml):
-# PHP version of the image. 8.3 = default | 8.4 | 8.5 (experimental).
+# PHP version of the image. 8.3 = default | 8.4 = experimental (runs Melis).
+# (8.5 not usable: Laminas deps cap at 8.4 → the build's create-project fails.)
 # PHP_VERSION=8.3
 
 # App

--- a/prebuilt/Dockerfile
+++ b/prebuilt/Dockerfile
@@ -6,8 +6,10 @@
 # native Melis web installer on first visit.
 #
 # PHP version is configurable: default 8.3 (officially supported by Melis 5.3.x).
-# Override with --build-arg PHP_VERSION=8.4|8.5 (or PHP_VERSION in .env via compose);
-# 8.4/8.5 are experimental (maintained Laminas forks, see melis-core#24).
+# Override with --build-arg PHP_VERSION=8.4 (or PHP_VERSION in .env via compose).
+# 8.4 is experimental but runs Melis. 8.5 is NOT usable yet: the skeleton's Laminas
+# deps cap at 8.4, so the create-project step below FAILS the build on 8.5
+# (see melis-core#24).
 ARG PHP_VERSION=8.3
 FROM php:${PHP_VERSION}-apache
 

--- a/prebuilt/Dockerfile
+++ b/prebuilt/Dockerfile
@@ -44,6 +44,12 @@ RUN apt-get update -y && apt-get upgrade -y \
 # Composer (kept at runtime too: the web installer adds modules via composer)
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 
+# Clone public github repos over HTTPS instead of SSH (the image has no ssh client
+# or keys). Needed when Composer resolves the public melisplatform Laminas forks
+# from their VCS source — e.g. on PHP 8.5, where the locked dist versions can't be
+# used. No-op for 8.3/8.4 (which install from dist). Public repos → no credentials.
+RUN git config --system url."https://github.com/".insteadOf "git@github.com:"
+
 # Apache: serve Melis from /public, enable rewrite
 COPY ./conf/vhost.conf /etc/apache2/sites-available/000-default.conf
 COPY ./conf/php.ini /usr/local/etc/php/conf.d/php-melis.ini

--- a/prebuilt/Dockerfile
+++ b/prebuilt/Dockerfile
@@ -4,7 +4,12 @@
 # needs a database and `docker run` — no Composer/build step on their machine.
 # DB schema, admin user and the optional demo site are still set up through the
 # native Melis web installer on first visit.
-FROM php:8.3-apache
+#
+# PHP version is configurable: default 8.3 (officially supported by Melis 5.3.x).
+# Override with --build-arg PHP_VERSION=8.4|8.5 (or PHP_VERSION in .env via compose);
+# 8.4/8.5 are experimental (maintained Laminas forks, see melis-core#24).
+ARG PHP_VERSION=8.3
+FROM php:${PHP_VERSION}-apache
 
 ARG APP_NAME=melis
 ARG TZ=Europe/Paris
@@ -26,8 +31,11 @@ RUN apt-get update -y && apt-get upgrade -y \
         libjpeg-dev libfreetype6-dev libjpeg62-turbo-dev zlib1g-dev libpng-dev \
         libicu-dev tzdata \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    # opcache: built into core on PHP 8.5+ (not a shared module), so only install
+    # it on < 8.5. Detected at build time → works for any PHP_VERSION.
+    && OPCACHE=$(php -r 'echo version_compare(PHP_VERSION, "8.5", "<") ? "opcache" : "";') \
     && docker-php-ext-install -j"$(nproc)" \
-        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif opcache \
+        mysqli pdo pdo_mysql xml mbstring curl zip gd intl exif $OPCACHE \
     && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone \
     && rm -rf /var/lib/apt/lists/*
 

--- a/prebuilt/conf/php.ini
+++ b/prebuilt/conf/php.ini
@@ -7,6 +7,14 @@ post_max_size = 64M
 date.timezone = Europe/Paris
 expose_php = Off
 
+; Don't render PHP errors into HTTP output — log them instead. This keeps AJAX/JSON
+; responses clean (PHP 8.5 emits many deprecations from Melis/Laminas/phing code;
+; if displayed they pollute installer AJAX and clutter the back-office). Errors are
+; still captured via `docker compose logs`.
+display_errors = Off
+log_errors = On
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
+
 opcache.enable = 1
 opcache.memory_consumption = 192
 opcache.max_accelerated_files = 20000

--- a/prebuilt/docker-compose.proxy.yml
+++ b/prebuilt/docker-compose.proxy.yml
@@ -1,0 +1,24 @@
+# Opt-in: run this stack behind the shared local nginx-proxy (see ../local-proxy).
+# Drops the published host port and exposes the app to the proxy via VIRTUAL_HOST.
+#
+#   docker network create webproxy                          # once
+#   docker compose -f ../local-proxy/docker-compose.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d
+#   # → http://${VIRTUAL_HOST:-melis-prebuilt.local}/   (add it to /etc/hosts → 127.0.0.1)
+#
+# Running several Melis stacks at once? Give each its own MELIS_CONTAINER_NAME and
+# VIRTUAL_HOST in its .env so container names and hostnames don't collide.
+services:
+  php:
+    # Remove the "8080:80" mapping from the base file — access is via the proxy.
+    ports: !reset []
+    environment:
+      VIRTUAL_HOST: ${VIRTUAL_HOST:-melis-prebuilt.local}
+      VIRTUAL_PORT: "80"
+    networks:
+      - melis
+      - webproxy
+
+networks:
+  webproxy:
+    external: true

--- a/prebuilt/docker-compose.yml
+++ b/prebuilt/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     #   args:
     #     APP_NAME: ${APP_NAME:-melis}
     #     TZ: ${TZ:-Europe/Paris}
+    #     PHP_VERSION: ${PHP_VERSION:-8.3}   # 8.3 (default) | 8.4 | 8.5 (experimental)
     container_name: ${MELIS_CONTAINER_NAME:-melis}-php
     depends_on:
       db:

--- a/prebuilt/docker-compose.yml
+++ b/prebuilt/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     #   args:
     #     APP_NAME: ${APP_NAME:-melis}
     #     TZ: ${TZ:-Europe/Paris}
-    #     PHP_VERSION: ${PHP_VERSION:-8.3}   # 8.3 (default) | 8.4 | 8.5 (experimental)
+    #     PHP_VERSION: ${PHP_VERSION:-8.3}   # 8.3 (default) | 8.4 (experimental). 8.5 not usable yet.
     container_name: ${MELIS_CONTAINER_NAME:-melis}-php
     depends_on:
       db:


### PR DESCRIPTION
## Summary

A tooling/docs pass on the Melis Docker stacks, centered on **PHP 8.5 support investigation** plus quality-of-life improvements. `latest` stays on **PHP 8.3** (officially supported); 8.4/8.5 are experimental.

## What's in here

### PHP 8.5 dev base images
- New `dev/php-apache-8.5` and `dev/php-fpm-8.5`; CI matrix extended to 8.5.
- Note: on 8.5 Zend OPcache is built into core, so `opcache` is **not** installed via `docker-php-ext-install` (it would fail); it's already loaded.

### Configurable PHP version in the runnable stacks
- `install/`, `prebuilt/`, `fpm/` take `ARG PHP_VERSION=8.3` → `FROM php:${PHP_VERSION}-{apache,fpm}`, wired into compose build args + `.env`.
- `opcache` is installed conditionally (`version_compare < 8.5`) so any version builds.

### PHP 8.5 findings (verified end-to-end → working back-office)
8.5 is **not a hard incompatibility** — a full install was driven to the working back-office. Two image-level fixes are included:
- **git → HTTPS** (`git config --system url.https://github.com/.insteadOf git@github.com:`): on 8.5 Composer resolves the public melisplatform Laminas forks from their `git@github` (SSH) VCS source; the image has no ssh client/keys, so module download fails. This was the hard blocker. No-op on 8.3/8.4.
- **php.ini** `display_errors=Off` + `log_errors=On` + `error_reporting` excluding `E_DEPRECATED` — 8.5 emits many deprecations (Melis/Laminas/phing); displaying them pollutes installer AJAX & the back-office.

Remaining 8.5 work is **upstream Melis** (documented in `CLAUDE.md`): deprecated `PDO::MYSQL_ATTR_INIT_COMMAND`, forced `display_errors=1` in melis-installer config, `ReflectionProperty::setAccessible()`, `phing`/`laminas-cache` deprecations.

### Developer experience
- Root **`Makefile`** (`make up|up-build|down|destroy|logs|shell|ps`, `proxy-up`, `PROXY=1`, `adminer`).
- **Troubleshooting / FAQ** section in the README; clearer per-path quick starts and tag list.
- Opt-in **Xdebug** in `install/` (`WITH_XDEBUG=1`).

### Shared local reverse-proxy (opt-in)
- `local-proxy/` (nginx-proxy) + per-stack `docker-compose.proxy.yml` so several stacks share `:80` by `VIRTUAL_HOST` (host port dropped via `!reset`). Purely opt-in — without the extra `-f`, stacks behave exactly as before.

### Docs
- New **`CLAUDE.md`** (project context, conventions, hard-won gotchas, CI, full 8.5 recipe).
- README/DOCKERHUB updated with 8.5 tags and accurate experimental status.

## Notes for reviewers
- `latest` / default stays PHP 8.3. 8.4 runs Melis; 8.5 needs the upstream cleanups above to complete out of the box.
- CI builds are multi-arch and build-only on PRs (no Docker Hub push without secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)